### PR TITLE
Add no_std attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! Helper functions for retrieving stdin, stdout, stderr to work with `libc`.
 #![warn(missing_docs)]
+#![no_std]
 
 extern crate libc;
 


### PR DESCRIPTION
I don't see any reason why this crate can't be no_std.